### PR TITLE
複数VMのデプロイができるように

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Local configuration files (sensitive or user-specific)
-config.yml
 terraform/terraform.tfvars
 
 # Terraform generated files (state, plugins, locks)

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,12 @@ cl: clean
 
 setup:
 	@echo "### Setting up and Verifying Configuration ###"
-	@cp --update=none config.yml.sample config.yml
 	@cp --update=none terraform/terraform.tfvars.sample terraform/terraform.tfvars
-	@echo "\n📄 Current 'config.yml':"
-	@echo "========================================================"
-	@cat config.yml
 	@echo "\n📄 Current 'terraform/terraform.tfvars':"
 	@echo "========================================================"
 	@cat terraform/terraform.tfvars
 	@echo "\n========================================================"
-	@echo "✅ Setup complete. Please review the configurations."
+	@echo "✅ Setup complete. Please review the configuration."
 	@echo "========================================================"
 
 init:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ cd "${project_name}/"
 
 # deploy
 make setup
-vim config.yml
 vim terraform/terraform.tfvars 
 make
 

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -2,31 +2,30 @@
   become: yes
   gather_facts: yes
   gather_subset: min
-  vars_files:
-    - ../config.yml
   tasks:
-    - name: Get server details from terraform output
+    - name: Get server details map from terraform output
       cloud.terraform.terraform_output:
         state_file: ../terraform/terraform.tfstate
-        name: server_details
+        name: servers_detail
       register: _result_tfo_main
 
-    - name: Get volume details from terraform output
+    - name: Get volume details map from terraform output
       cloud.terraform.terraform_output:
         state_file: ../terraform/terraform.tfstate
-        name: volume_details
+        name: volumes_detail
       register: _result_tfo_vol
       failed_when: false
 
-    - name: Define server host in dynamic inventory
+    - name: Define server hosts in dynamic inventory
       add_host:
-        name: "{{ _result_tfo_main.value.name }}"
+        name: "{{ item.value.name }}"
         groups: vms
-        ansible_host: "{{ _result_tfo_main.value.floating_ip }}"
-        ansible_user: "{{ ssh_user }}"
-        ansible_ssh_private_key_file: "{{ ssh_key_path }}"
-        vol_device_path: "{{ _result_tfo_vol.value.device | default(omit) }}"
-        vol_mount_path: "{{ volume_mount_path | default(omit) }}"
+        ansible_host: "{{ item.value.floating_ip }}"
+        ansible_user: "{{ item.value.ssh_user }}"
+        ansible_ssh_private_key_file: "{{ item.value.ssh_key_path }}"
+        vol_device_path: "{{ _result_tfo_vol.value[item.key].device_path | default(omit) }}"
+        vol_mount_path: "{{ _result_tfo_vol.value[item.key].mount_path | default(omit) }}"
+      loop: "{{ _result_tfo_main.value | dict2items }}"
 
 - hosts: vms
   become: yes

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -1,3 +1,0 @@
-ssh_user: almalinux
-ssh_key_path: /keys/github.id_rsa
-# volume_mount_path: /backup

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,22 +10,14 @@ terraform {
 
 provider "openstack" {}
 
-locals {
-  config = yamldecode(file("../config.yml"))
-}
-
 module "ssh_config" {
   source = "git::https://github.com/teityura/terraform-modules.git//ssh-config"
-
-  server_details = module.vm_openstack.server_details
+  servers_detail = module.vm_openstack.servers_detail
   project_name = basename(abspath("${path.module}/.."))
-  ssh_user = local.config.ssh_user
-  ssh_key_path = local.config.ssh_key_path
 }
 
 module "vm_openstack" {
   source = "git::https://github.com/teityura/terraform-modules.git//vm-openstack"
-
-  server_config = var.server_config
-  volume_config = var.volume_config
+  servers_config = var.servers_config 
+  volumes_config = var.volumes_config
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,12 +3,12 @@ output "ssh_config_path" {
   value = module.ssh_config.filename
 }
 
-output "server_details" {
-  description = "Details of the created server."
-  value = module.vm_openstack.server_details
+output "servers_detail" {
+  description = "Details of the created servers."
+  value = module.vm_openstack.servers_detail
 }
 
-output "volume_details" {
-  description = "Details of the created data volume."
-  value = module.vm_openstack.volume_details
+output "volumes_detail" {
+  description = "Details of the created data volumes."
+  value = module.vm_openstack.volumes_detail
 }

--- a/terraform/terraform.tfvars.sample
+++ b/terraform/terraform.tfvars.sample
@@ -1,14 +1,33 @@
-server_config = {
-  name = "tpl"
-  flavor_id = "xxxxx"
-  image_id = "xxxxx"
-  key_pair = "key_name"
-  volume_size = 30
-  security_groups = ["security_group1"]
-  net_int = "int_net"
-  net_ext = "ext_net"
+servers_config = {
+  web01 = {
+    name = "web01"
+    flavor_id = "xxxxx"
+    image_id = "xxxxx"
+    key_pair = "key_name"
+    volume_size = 10
+    security_groups = ["security_group1"]
+    net_int = "int_net"
+    net_ext = "ext_net"
+    ssh_user = "almalinux"
+    ssh_key_path = "/keys/web01.id_rsa"
+  },
+  db01 = {
+    name = "db01"
+    flavor_id = "xxxxx"
+    image_id = "xxxxx"
+    key_pair = "key_name"
+    volume_size = 10
+    security_groups = ["security_group1"]
+    net_int = "int_net"
+    net_ext = "ext_net"
+    ssh_user = "almalinux"
+    ssh_key_path = "/keys/db01.id_rsa"
+  }
 }
 
-# volume_config = {
-#   volume_size = 50
+# volumes_config = {
+#   db01 = { 
+#     volume_size = 50,
+#     volume_mount_path = "/var/lib/mysql"
+#   }
 # }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,6 +1,6 @@
-variable "server_config" {
-  description = "Configuration for server."
-  type = object({
+variable "servers_config" {
+  description = "Configuration for servers."
+  type = map(object({
     name = string
     flavor_id = string
     image_id = string
@@ -9,14 +9,17 @@ variable "server_config" {
     security_groups = list(string)
     net_int = string
     net_ext = string
-  })
+    ssh_user = string
+    ssh_key_path = string
+  }))
 }
 
-variable "volume_config" {
-  description = "Configuration for volume."
-  type = object({
+variable "volumes_config" {
+  description = "Configuration for volumes."
+  type = map(object({
     volume_size = number
-  })
+    volume_mount_path = optional(string)
+  }))
   default = null
   nullable = true
 }


### PR DESCRIPTION
## Why

単一のVMのデプロイしかできなかった

## What

複数のVMのデプロイに対応させた

## How

- server_details を map で 複数定義するように
- config.yml を廃止
  - ssh_user を servers_detail に統合
  - volume_mount_path を volumes_detail に統合
