### PR TITLE
terraform-project の利用を中止する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Local configuration files
-ansible/site.yml
+ansible/inventory/hosts
 terraform/terraform.tfvars
 
 # Terraform generated files (state, plugins, locks)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-.PHONY: default deploy config init apply clean play
+.PHONY: default deploy tfvars init apply clean play
 
 default: deploy
 deploy: init apply play
 cl: clean
+
+tfvars:
+	test -f terraform/terraform.tfvars || \
+	  cp terraform/terraform.tfvars.sample terraform/terraform.tfvars
 
 init:
 	terraform -chdir=terraform init
@@ -11,7 +15,7 @@ apply: init
 	terraform -chdir=terraform apply -auto-approve
 
 play:
-	(cd ansible && ansible-playbook -v site.yml)
+	(cd ansible && ansible-playbook -v setup.yml)
 
 clean:
 	terraform -chdir=terraform destroy -auto-approve

--- a/README.md
+++ b/README.md
@@ -6,17 +6,53 @@ This repository is a collection of reusable Terraform and Ansible templates for 
 
 This template is designed to be used as a git submodule in your project.
 
+``` bash
+# Setup (change workspace and project_name as needed)
+workspace="${HOME}/terra"
+project_name="myproject"
+
+mkdir -p "${workspace}/${project_name}"
+cd "${workspace}/${project_name}"
+git init
+git submodule add https://github.com/teityura/terraform-template.git template
+
+# Deploy
+cd template && make tfvars
+vim terraform/terraform.tfvars
+make
+
+# Destroy
+make clean
+```
+
 ### Example Project Structure
 
 ``` log
-your-project/
-├── Makefile            # See terraform-project for example
-├── terraform.tfvars    # Your configuration
-├── site.               # Your Ansible playbook
-└── template/           # This repository as submodule
-    ├── terraform/
-    └── ansible/
+~/terra/proj_name/
+├── site.yml                # Your Ansible playbook
+├── inventory/
+│   ├── hosts               # Your Ansible inventory
+│   ├── host_vars/
+│   └── group_vars/
+|       └── vms/
+|           └── main.yml
+├── template/               # This repository as submodule
+│   ├── terraform/
+│   └── ansible/
+└── roles/                  # Your Ansible roles
 ```
 
-See [terraform-project](https://github.com/teityura/terraform-project) for a complete example.
+## Optional Settings
 
+``` log
+cd ~/terra/proj_name/
+bash template/setup.sh
+ansible-playbook site.yml
+```
+
+## Update Submodule
+
+``` bash
+git submodule update --remote template
+git add template && git commit -m "Update submodule"
+```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This template is designed to be used as a git submodule in your project.
 ``` bash
 # Setup (change workspace and project_name as needed)
 workspace="${HOME}/terra"
-project_name="myproject"
+project_name="proj_name"
 
 mkdir -p "${workspace}/${project_name}"
 cd "${workspace}/${project_name}"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ workspace="${HOME}/terra"
 project_name="proj_name"
 
 mkdir -p "${workspace}/${project_name}"
-cd "${workspace}/${project_name}"
+cd "${workspace}/${project_name}/"
 git init
 git submodule add https://github.com/teityura/terraform-template.git template
 
@@ -20,34 +20,38 @@ git submodule add https://github.com/teityura/terraform-template.git template
 cd template && make tfvars
 vim terraform/terraform.tfvars
 make
+./setup.sh
+
+# Play
+cd "${workspace}/${project_name}/"
+ansible-playbook site.yml
 
 # Destroy
-make clean
+cd template && make clean
 ```
 
 ### Example Project Structure
 
 ``` log
 ~/terra/proj_name/
-├── site.yml                # Your Ansible playbook
-├── inventory/
-│   ├── hosts               # Your Ansible inventory
+├── .git/
+├── .gitignore              # Excludes ansible.cfg
+├── .gitmodules
+├── ansible.cfg -> template/ansible/ansible.cfg  # Linked config
+├── site.yml                # Main playbook
+├── inventories/
+│   ├── hosts               # Inventory definitions
 │   ├── host_vars/
 │   └── group_vars/
-|       └── vms/
+|       └── all/
 |           └── main.yml
-├── template/               # This repository as submodule
-│   ├── terraform/
-│   └── ansible/
-└── roles/                  # Your Ansible roles
-```
-
-## Optional Settings
-
-``` log
-cd ~/terra/proj_name/
-bash template/setup.sh
-ansible-playbook site.yml
+├── roles/                  # Ansible roles
+│   └── sample/
+|       └── tasks/
+|           └── main.yml
+└── template/               # Submodule (terraform-template)
+    ├── terraform/
+    └── ansible/
 ```
 
 ## Update Submodule

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,8 +1,7 @@
 [defaults]
 # === Required settings ===
 host_key_checking = False
-inventory = ../../inventories/hosts
-roles_path = ./roles:../../roles
+inventory = $PWD/inventories/hosts
 
 # === Optional settings ===
 force_color = 1

--- a/ansible/roles/sample/tasks/main.yml
+++ b/ansible/roles/sample/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Show system information
+  shell: |
+    echo "=== Hostname ==="
+    cat /etc/hostname
+    echo -e "\n=== OS Release ==="
+    cat /etc/os-release
+    echo -e "\n=== CPU ==="
+    lscpu | head -15
+    echo -e "\n=== Memory ==="
+    free -h
+    echo -e "\n=== Block Devices ==="
+    lsblk
+  register: _result_sysinfo
+  changed_when: false
+
+- name: Display system information
+  debug:
+    var: _result_sysinfo.stdout_lines

--- a/ansible/roles/setup/tasks/generate_inventory.yml
+++ b/ansible/roles/setup/tasks/generate_inventory.yml
@@ -1,0 +1,16 @@
+---
+- name: Create inventory directory
+  file:
+    path: "{{ Inventory_path | dirname }}"
+    state: directory
+    mode: '0755'
+
+- name: Generate inventory file
+  template:
+    src: hosts.j2
+    dest: "{{ Inventory_path }}"
+    mode: '0644'
+
+- name: Display inventory content
+  debug:
+    msg: "{{ lookup('file', Inventory_path).split('\n') }}"

--- a/ansible/roles/setup/templates/hosts.j2
+++ b/ansible/roles/setup/templates/hosts.j2
@@ -1,4 +1,4 @@
-[vms]
-{% for host in groups['vms'] %}
+[all]
+{% for host in groups['all'] %}
 {{ hostvars[host].inventory_hostname }}
 {% endfor %}

--- a/ansible/roles/setup/templates/hosts.j2
+++ b/ansible/roles/setup/templates/hosts.j2
@@ -1,0 +1,4 @@
+[vms]
+{% for host in groups['vms'] %}
+{{ hostvars[host].inventory_hostname }}
+{% endfor %}

--- a/ansible/sample.yml
+++ b/ansible/sample.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: vms
+- hosts: all
   become: yes
   gather_facts: no
   roles:

--- a/ansible/sample.yml
+++ b/ansible/sample.yml
@@ -1,0 +1,6 @@
+---
+- hosts: vms
+  become: yes
+  gather_facts: no
+  roles:
+    - role: sample

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -20,7 +20,7 @@
     - name: Define server hosts in dynamic inventory
       add_host:
         name: "{{ item.value.name }}"
-        groups: vms
+        groups: all
         ansible_host: "{{ item.value.floating_ip }}"
         ansible_user: "{{ item.value.ssh_user }}"
         ansible_ssh_private_key_file: "{{ item.value.ssh_key_path }}"
@@ -39,7 +39,7 @@
         Inventory_path: "{{ playbook_dir }}/inventories/hosts"
 
 
-- hosts: vms
+- hosts: all
   become: yes
   gather_facts: no
   pre_tasks:

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -28,6 +28,17 @@
         vol_mount_path: "{{ _result_tfo_vol.value[item.key].mount_path | default(omit) }}"
       loop: "{{ _result_tfo_main.value | dict2items }}"
 
+
+- hosts: localhost
+  tasks:
+    - name: Generate inventory file
+      include_role:
+        name: setup
+        tasks_from: generate_inventory
+      vars:
+        Inventory_path: "{{ playbook_dir }}/inventories/hosts"
+
+
 - hosts: vms
   become: yes
   gather_facts: no

--- a/setup.sh
+++ b/setup.sh
@@ -22,4 +22,10 @@ fi
 ln -sf template/ansible/ansible.cfg ansible.cfg
 test -f .gitignore || echo 'ansible.cfg' > .gitignore
 
+# show summary
+set -x
+pwd
+ls -al --color=always
+{ set +x; } 2>/dev/null
+
 exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Move to project root (template/..)
+cd "$(dirname "$0")/.."
+
+# copy sample playbook
+test -f site.yml || cp template/ansible/sample.yml site.yml
+
+# copy sample role
+if [ ! -d roles/sample ]; then
+  mkdir -p roles
+  cp -r template/ansible/roles/sample roles/
+fi
+
+# copy inventory
+if [ ! -d inventories ]; then
+  mkdir -p inventories
+  cp -r template/ansible/inventories/* inventories/
+fi
+
+# link ansible.cfg
+ln -sf template/ansible/ansible.cfg ansible.cfg
+test -f .gitignore || echo 'ansible.cfg' > .gitignore
+
+exit 0


### PR DESCRIPTION
## Why

template 利用して開発する際、ansible のロジックにだけ集中したいが、
動的インベントリの生成処理が、2重管理になっていた

## What

terraform-template を submodule として追加する設計に変更する

- ansible/inventories/hosts を生成する
- setup.sh で inventories/ や roles/ を ../  にコピーする

### Example Project Structure

``` log
~/terra/proj_name/
├── .git/
├── .gitignore              # Excludes ansible.cfg
├── .gitmodules
├── ansible.cfg -> template/ansible/ansible.cfg  # Linked config
├── site.yml                # Main playbook
├── inventories/
│   ├── hosts               # Inventory definitions
│   ├── host_vars/
│   └── group_vars/
|       └── all/
|           └── main.yml
├── roles/                  # Ansible roles
│   └── sample/
|       └── tasks/
|           └── main.yml
└── template/               # Submodule (terraform-template)
    ├── terraform/
    └── ansible/
```
