### PR TITLE
fix project_name

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,7 +13,7 @@ provider "openstack" {}
 module "ssh_config" {
   source = "git::https://github.com/teityura/terraform-modules.git//ssh-config"
   servers_detail = module.vm_openstack.servers_detail
-  project_name = basename(abspath("${path.module}/.."))
+  project_name = basename(abspath("${path.module}/../.."))
 }
 
 module "vm_openstack" {


### PR DESCRIPTION
## Why

template を submodule として追加したため、
project の ルートディレクトリ が1つ上の階層になった

## What

project_name の取得方法を修正